### PR TITLE
Payload application base images

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,88 @@
+name: master
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+
+  build-and-publish-cpp-app-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build SDK dependencies
+      run: docker run --platform linux/amd64 -v $PWD:/workspace quay.io/antaris-inc/satos-payload-sdk-tools:stable make api_lib agent_package
+
+    - name: Package cpp lib
+      run: docker run --platform linux/amd64 -v $PWD:/workspace quay.io/antaris-inc/satos-payload-sdk-tools:stable make cpp_package
+
+    - name: Login to image registry
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build image
+      run: docker build -f app-images/cpp/Dockerfile -t quay.io/antaris-inc/satos-payload-app-cpp:${GITHUB_SHA} .
+
+    - name: Push image
+      run: docker push quay.io/antaris-inc/satos-payload-app-cpp:${GITHUB_SHA}
+
+
+  build-and-publish-python-app-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build SDK dependencies
+      run: docker run --platform linux/amd64 -v $PWD:/workspace quay.io/antaris-inc/satos-payload-sdk-tools:stable make api_lib agent_package
+
+    - name: Package python lib
+      run: docker run --platform linux/amd64 -v $PWD:/workspace quay.io/antaris-inc/satos-payload-sdk-tools:stable make python_package
+
+    - name: Login to image registry
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build image
+      run: docker build -f app-images/python/Dockerfile -t quay.io/antaris-inc/satos-payload-app-python:${GITHUB_SHA} .
+
+    - name: Push image
+      run: docker push quay.io/antaris-inc/satos-payload-app-python:${GITHUB_SHA}
+
+
+  build-and-publish-tools-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build image
+      run: docker build -f build-tools/containers/Dockerfile.build.x86_64 -t quay.io/antaris-inc/satos-payload-sdk-tools:${GITHUB_SHA} .
+
+    - name: Login to image registry
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Push image
+      run: docker push quay.io/antaris-inc/satos-payload-sdk-tools:${GITHUB_SHA}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-.PHONY: no_default pc_submodule_tools build_shell gen old_gen api_lib api_lib_clean gen_clean pc_sim pc_sim_clean sample_app sample_app_clean clean sdk_pkg payload_app_pkg docker_img
+.PHONY: no_default pc_submodule_tools build_shell gen old_gen api_lib api_lib_clean gen_clean pc_sim pc_sim_clean sample_app sample_app_clean clean sdk_pkg payload_app_pkg docker_img python_package cpp_package agent_package
 
 ARCH=x86_64
 SHELL := /bin/bash
@@ -136,6 +136,16 @@ pc_sim:
 	g++ -g ${PC_SIM_DIR}/antaris_pc_stub.cc ${PC_SIM_DIR}/config_db.cc  ${THIRD_PARTY_INCLUDES} -I ${OUTPUT_GEN_DIR} -I ${CPP_LIB_DIR}/include -L ${OUTPUT_LIB_DIR} -lantaris_api -lpthread ${GRPC_CPP_ADDITIONAL_LIBS} -o ${PC_SIM_DIR}/pc-sim ; 	\
 
 	@tree ${PC_SIM_DIR}
+
+
+agent_package:
+	./build-tools/scripts/package-agent.sh
+
+python_package:
+	./build-tools/scripts/package-python-lib.sh
+
+cpp_package:
+	./build-tools/scripts/package-cpp-lib.sh
 
 sample_app:
 	@if [ "${LANGUAGE}" == "python" ]; then																		\

--- a/app-images/cpp/Dockerfile
+++ b/app-images/cpp/Dockerfile
@@ -1,0 +1,44 @@
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:22.04 as shared_app_image
+COPY app-images/shared/root-entrypoint.sh /entrypoint.sh
+CMD /entrypoint.sh
+RUN mkdir -p /opt/antaris/app /opt/antaris/logs
+
+
+# This image layers on support for cpp-based payload applications
+FROM shared_app_image as cpp_app_image
+
+RUN mkdir /stage
+COPY dist/satos-payload-sdk-cpp.deb /stage
+RUN apt update && apt install -y /stage/satos-payload-sdk-cpp.deb
+RUN rm -fr /stage
+
+
+# This image adds the SDK agent dependencies
+FROM cpp_app_image as cpp_app_image_with_sdk_agent
+
+RUN mkdir -p /opt/antaris/sdk-agent
+
+RUN mkdir /stage
+COPY dist/satos-payload-sdk-agent.deb /stage
+RUN apt update && apt install -y /stage/satos-payload-sdk-agent.deb
+RUN rm -fr /stage
+
+ENV RUN_SDK_AGENT=1
+
+# assume if SDK agent is installed that we will need a workspace
+RUN mkdir /workspace
+WORKDIR /workspace

--- a/app-images/python/Dockerfile
+++ b/app-images/python/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:22.04 as shared_app_image
+COPY app-images/shared/root-entrypoint.sh /entrypoint.sh
+CMD /entrypoint.sh
+RUN mkdir -p /opt/antaris/app /opt/antaris/logs
+
+
+# This image layers on support for python-based payload applications
+FROM shared_app_image as python_app_image
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y python3 python3-pip
+RUN python3 -m pip install --upgrade pip
+
+RUN mkdir /stage
+COPY lib/python/dist/satos_payload_sdk-*.whl /stage
+RUN python3 -m pip install /stage/satos_payload_sdk-*.whl
+RUN rm -fr /stage
+
+
+# This image adds the SDK agent dependencies
+FROM python_app_image as python_app_image_with_sdk_agent
+
+RUN mkdir -p /opt/antaris/sdk-agent
+
+RUN mkdir /stage
+COPY dist/satos-payload-sdk-agent.deb /stage
+RUN apt update && apt install -y /stage/satos-payload-sdk-agent.deb
+RUN rm -fr /stage
+
+ENV RUN_SDK_AGENT=1
+
+# assume if SDK agent is installed that we will need a workspace
+RUN mkdir /workspace
+WORKDIR /workspace

--- a/app-images/shared/root-entrypoint.sh
+++ b/app-images/shared/root-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "${RUN_SDK_AGENT}" != "" ]; then
+
+	if [ "${CONFIG}" == "" ]; then
+		echo "CONFIG must be set"
+		exit 2
+	fi
+
+	CONFIG_ABS=`pwd`/${CONFIG}
+
+	rm -fr /tmp/sdk-agent-init/
+	mkdir -p /tmp/sdk-agent-init/
+	cd /tmp/sdk-agent-init/
+	unzip ${CONFIG_ABS}
+	dpkg -i *.deb
+
+	/opt/antaris/sdk-agent/run-agent.sh &> /opt/antaris/logs/sdk-agent.log &
+fi
+
+CONFIG_FILE=/opt/antaris/app/config.json
+if [ ! -f "${CONFIG_FILE}" ]; then
+	echo "config file not found at ${CONFIG_FILE}"
+	exit 1
+fi
+
+# execute entrypoint based on config
+ENTRYPOINT_FILE=`jq --raw-output  '.Storage.Entrypoint_File' ${CONFIG_FILE}`
+$ENTRYPOINT_FILE

--- a/build-tools/containers/Dockerfile.build.x86_64
+++ b/build-tools/containers/Dockerfile.build.x86_64
@@ -57,7 +57,7 @@ RUN cd /tmp/;\
 # install grpc components, see https://grpc.io/docs/languages/
 # python grpc
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install grpcio grpcio-tools
+RUN python3 -m pip install build grpcio grpcio-tools
 
 ARG ANTARIS_INSTALLATIONS_PATH=/usr/local/antaris
 

--- a/build-tools/scripts/package-agent.sh
+++ b/build-tools/scripts/package-agent.sh
@@ -25,6 +25,7 @@ mkdir -p $DEB_OUTPUT_DIR $DEB_OUTPUT_DIR/DEBIAN
 # Copy files from into appropriate locations
 
 mkdir -p $DEB_OUTPUT_DIR/opt/antaris/sdk-agent
+cp $BUILD_ROOT/sdk-agent/run-agent.sh $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/
 cp $BUILD_ROOT/lib/proxy/proxy-agent/agent.py $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/
 cp $BUILD_ROOT/lib/proxy/proxy-agent/hexdump.py $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/
 cp $BUILD_ROOT/lib/proxy/proxy-agent/socket_proxy.py $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/

--- a/build-tools/scripts/package-agent.sh
+++ b/build-tools/scripts/package-agent.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEB_NAME="satos-payload-sdk-agent"
+BUILD_ROOT=`pwd`
+VERSION=`cat $BUILD_ROOT/VERSION`
+OUTPUT_DIR="$BUILD_ROOT/dist"
+DEB_OUTPUT_DIR="$OUTPUT_DIR/$DEB_NAME"
+
+mkdir -p $DEB_OUTPUT_DIR $DEB_OUTPUT_DIR/DEBIAN
+
+# Copy files from into appropriate locations
+
+mkdir -p $DEB_OUTPUT_DIR/opt/antaris/sdk-agent
+cp $BUILD_ROOT/lib/proxy/proxy-agent/agent.py $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/
+cp $BUILD_ROOT/lib/proxy/proxy-agent/hexdump.py $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/
+cp $BUILD_ROOT/lib/proxy/proxy-agent/socket_proxy.py $DEB_OUTPUT_DIR/opt/antaris/sdk-agent/
+
+
+# Set package metadata and build
+
+cat << EOM > $DEB_OUTPUT_DIR/DEBIAN/control
+Package: $DEB_NAME
+Version: $VERSION
+Maintainer: antaris
+Architecture: amd64
+Description: SatOS Payload SDK agent
+Depends: unzip, jq
+EOM
+
+cd "$OUTPUT_DIR"
+dpkg-deb --build "$DEB_NAME"
+
+if [ $? -eq 0 ]
+then
+	echo "Packaged $DEB_NAME.deb successfully"
+fi

--- a/build-tools/scripts/package-cpp-lib.sh
+++ b/build-tools/scripts/package-cpp-lib.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEB_NAME="satos-payload-sdk-cpp"
+BUILD_ROOT=`pwd`
+VERSION=`cat $BUILD_ROOT/VERSION`
+OUTPUT_DIR="$BUILD_ROOT/dist"
+DEB_OUTPUT_DIR="$OUTPUT_DIR/$DEB_NAME"
+
+mkdir -p $DEB_OUTPUT_DIR $DEB_OUTPUT_DIR/DEBIAN
+
+# Copy files from lib/cpp into appropriate locations
+
+mkdir -p $DEB_OUTPUT_DIR/lib/antaris
+cp $BUILD_ROOT/lib/cpp/libantaris_api.a $DEB_OUTPUT_DIR/lib/antaris
+
+mkdir -p $DEB_OUTPUT_DIR/lib/antaris/gen
+cp $BUILD_ROOT/lib/cpp/gen/antaris_api.h $DEB_OUTPUT_DIR/lib/antaris/gen
+
+mkdir -p $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_api_common.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_api_internal.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_cpp_standard_includes.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_pc_to_app_api.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_sdk_environment.h $DEB_OUTPUT_DIR/lib/antaris/include
+
+
+# Set package metadata and build
+
+cat << EOM > $DEB_OUTPUT_DIR/DEBIAN/control
+Package: $DEB_NAME
+Version: $VERSION
+Maintainer: antaris
+Architecture: amd64
+Description: C++ SatOS payload application library
+EOM
+
+cd "$OUTPUT_DIR"
+dpkg-deb --build "$DEB_NAME"
+
+if [ $? -eq 0 ]
+then
+	echo "Packaged $DEB_NAME.deb successfully"
+fi

--- a/build-tools/scripts/package-python-lib.sh
+++ b/build-tools/scripts/package-python-lib.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUILD_ROOT=`pwd`
+mkdir -p $BUILD_ROOT/dist
+
+cd lib/python
+python3 -m build
+cp dist/*.whl $BUILD_ROOT/dist

--- a/sdk-agent/run-agent.sh
+++ b/sdk-agent/run-agent.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+#
+# Copyright 2023 Antaris, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CONFIG_FILE="/opt/antaris/app/config.json"
+
+RUN_PROXY=`jq --raw-output  '.Proxy.Run_Proxy' ${CONFIG_FILE}`
+if [[ ${RUN_PROXY} != "1" ]]; then
+	echo "Config indicates proxy should be disabled, exiting."
+	exit 1
+fi
+
+PROXY_IP=`jq --raw-output  '.Proxy.Proxy_IP' ${CONFIG_FILE}`
+PROXY_PORT=`jq --raw-output  '.Proxy.Proxy_Port' ${CONFIG_FILE}`
+
+python3 /opt/antaris/sdk-agent/agent.py -m user -i ${PROXY_IP} -p ${PROXY_PORT} -s 127.0.0.1 -t 50051 -l 127.0.0.1 -o 50053


### PR DESCRIPTION
In summary, this introduces new docker images and packaging that allow a user to package their python or CPP payload application on top of publicly-available base images. This also incorporates the SDK agent and automates its execution to simplify testing with the Antaris Cloud Platform.

Please read through each commit, as they have been well-formed to explain the additions.

I will remove the temporary modification to the github workflow before merging.

Please find an example of using the python app image in the SatOS-Payload-Demos repo: https://github.com/antaris-inc/SatOS-Payload-Demos/compare/master...bw-appimage