### PR TITLE
Keepalive 

### DIFF
--- a/lib/cpp/antaris_api_client.cc
+++ b/lib/cpp/antaris_api_client.cc
@@ -463,6 +463,19 @@ void *start_callback_server(void *thread_param)
     // clients. In this case it corresponds to an *synchronous* service.
     builder.RegisterService(&ctx->callback_service_handle);
 
+    // Sample way of setting keepalive arguments on the server. Here, we are
+    // configuring the server to send keepalive pings at a period of 10 minutes
+    // with a timeout of 20 seconds. Additionally, pings will be sent even if
+    // there are no calls in flight on an active HTTP2 connection. When receiving
+    // pings, the server will permit pings at an interval of 10 seconds.
+    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIME_MS,
+                               10 * 60 * 1000 /*10 min*/);
+    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+                               20 * 1000 /*20 sec*/);
+    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+    builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS,
+                               10 * 1000 /*10 sec*/);
+
     ctx->callback_service_handle.set_client_channel_ctx(ctx);
 
     // Finally assemble the server.

--- a/lib/cpp/antaris_api_client.cc
+++ b/lib/cpp/antaris_api_client.cc
@@ -43,6 +43,8 @@ unsigned int api_debug = 0;
 
 extern char g_SSL_ENABLE;
 
+extern char g_KEEPALIVE_ENABLE;
+
 #define ANTARIS_CALLBACK_GRACE_DELAY    10
 
 class PCServiceClient {
@@ -463,18 +465,20 @@ void *start_callback_server(void *thread_param)
     // clients. In this case it corresponds to an *synchronous* service.
     builder.RegisterService(&ctx->callback_service_handle);
 
-    // Sample way of setting keepalive arguments on the server. Here, we are
-    // configuring the server to send keepalive pings at a period of 10 minutes
-    // with a timeout of 20 seconds. Additionally, pings will be sent even if
-    // there are no calls in flight on an active HTTP2 connection. When receiving
-    // pings, the server will permit pings at an interval of 10 seconds.
-    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIME_MS,
-                               10 * 60 * 1000 /*10 min*/);
-    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
-                               20 * 1000 /*20 sec*/);
-    builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-    builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS,
-                               10 * 1000 /*10 sec*/);
+    if (g_KEEPALIVE_ENABLE == ENABLED) {
+        // Sample way of setting keepalive arguments on the server. Here, we are
+        // configuring the server to send keepalive pings at a period of 10 minutes
+        // with a timeout of 20 seconds. Additionally, pings will be sent even if
+        // there are no calls in flight on an active HTTP2 connection. When receiving
+        // pings, the server will permit pings at an interval of 10 seconds.
+        builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIME_MS,
+                                   10 * 60 * 1000 /*10 min*/);
+        builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+                                   20 * 1000 /*20 sec*/);
+        builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+        builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS,
+                                   10 * 1000 /*10 sec*/);
+    }
 
     ctx->callback_service_handle.set_client_channel_ctx(ctx);
 

--- a/lib/cpp/antaris_api_client.cc
+++ b/lib/cpp/antaris_api_client.cc
@@ -465,21 +465,6 @@ void *start_callback_server(void *thread_param)
     // clients. In this case it corresponds to an *synchronous* service.
     builder.RegisterService(&ctx->callback_service_handle);
 
-    if (g_KEEPALIVE_ENABLE == ENABLED) {
-        // Sample way of setting keepalive arguments on the server. Here, we are
-        // configuring the server to send keepalive pings at a period of 10 minutes
-        // with a timeout of 20 seconds. Additionally, pings will be sent even if
-        // there are no calls in flight on an active HTTP2 connection. When receiving
-        // pings, the server will permit pings at an interval of 10 seconds.
-        builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIME_MS,
-                                   10 * 60 * 1000 /*10 min*/);
-        builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
-                                   20 * 1000 /*20 sec*/);
-        builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-        builder.AddChannelArgument(GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS,
-                                   10 * 1000 /*10 sec*/);
-    }
-
     ctx->callback_service_handle.set_client_channel_ctx(ctx);
 
     // Finally assemble the server.

--- a/lib/cpp/antaris_api_server.cc
+++ b/lib/cpp/antaris_api_server.cc
@@ -46,6 +46,7 @@ using grpc::Server;
 using grpc::ServerBuilder;
 using grpc::Status;
 
+extern char if g_KEEPALIVE_ENABLE;
 
 static AntarisReturnCode
 prepare_endpoint_string(std::string &out_string, INT8 *peer_ip_str, UINT16 port);
@@ -555,15 +556,15 @@ PCToAppClientContext an_pc_pa_create_client(INT8 *peer_ip_str, UINT16 port, INT8
     if (An_SUCCESS != prepare_endpoint_string(internal_ctx->client_cb_endpoint, peer_ip_str, port)) {
         goto fail_cleanup_ctx;
     }
-   
-    // Sample way of setting keepalive arguments on the client channel. Here we
-    // are configuring a keepalive time period of 20 seconds, with a timeout of 10
-    // seconds. Additionally, pings will be sent even if there are no calls in
-    // flight on an active connection.
-    args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 20 * 1000 /*20 sec*/);
-    args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10 * 1000 /*10 sec*/);
-    args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-
+    if (g_KEEPALIVE_ENABLE == ENABLED) {
+        // Sample way of setting keepalive arguments on the client channel. Here we
+        // are configuring a keepalive time period of 20 seconds, with a timeout of 10
+        // seconds. Additionally, pings will be sent even if there are no calls in
+        // flight on an active connection.
+        args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 20 * 1000 /*20 sec*/);
+        args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10 * 1000 /*10 sec*/);
+        args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+    }   
     if (ssl_flag) {
         std::ifstream t(client_ssl_addr);
         std::string cacert;
@@ -579,11 +580,17 @@ PCToAppClientContext an_pc_pa_create_client(INT8 *peer_ip_str, UINT16 port, INT8
         ssl_opts.pem_root_certs=cacert;
 
         auto ssl_creds = grpc::SslCredentials(ssl_opts);
-    //    internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateChannel(internal_ctx->client_cb_endpoint, ssl_creds));
-        internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateCustomChannel(internal_ctx->client_cb_endpoint, ssl_creds, args));
+        if (g_KEEPALIVE_ENABLE == ENABLED) { 
+            internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateCustomChannel(internal_ctx->client_cb_endpoint, ssl_creds, args));
+        } else {
+            internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateChannel(internal_ctx->client_cb_endpoint, ssl_creds));
+        }
     } else {
-    //    internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateChannel(internal_ctx->client_cb_endpoint, grpc::InsecureChannelCredentials()));
-        internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateCustomChannel(internal_ctx->client_cb_endpoint, grpc::InsecureChannelCredentials(), args));
+        if (g_KEEPALIVE_ENABLE == ENABLED) {
+            internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateCustomChannel(internal_ctx->client_cb_endpoint, grpc::InsecureChannelCredentials(), args));
+        } else {
+            internal_ctx->client_api_handle = new AppToPCClient(grpc::CreateChannel(internal_ctx->client_cb_endpoint, grpc::InsecureChannelCredentials()));
+        }
     }
     if (!internal_ctx->client_api_handle) {
         goto fail_cleanup_ctx;

--- a/lib/cpp/antaris_api_server.cc
+++ b/lib/cpp/antaris_api_server.cc
@@ -561,9 +561,9 @@ PCToAppClientContext an_pc_pa_create_client(INT8 *peer_ip_str, UINT16 port, INT8
         // are configuring a keepalive time period of 20 seconds, with a timeout of 10
         // seconds. Additionally, pings will be sent even if there are no calls in
         // flight on an active connection.
-        args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 20 * 1000 /*20 sec*/);
-        args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10 * 1000 /*10 sec*/);
-        args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+        args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, KEEPALIVE_TIME_MS);
+        args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, KEEPALIVE_TIMEOUT_MS);
+        args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, KEEPALIVE_PERMIT_WITHOUT_CALLS);
     }   
     if (ssl_flag) {
         std::ifstream t(client_ssl_addr);

--- a/lib/cpp/antaris_sdk_environment.cc
+++ b/lib/cpp/antaris_sdk_environment.cc
@@ -33,6 +33,7 @@ static char g_CONF_JSON[MAX_FILE_OR_PROP_LEN_NAME]="/opt/antaris/app/config.json
 #define LISTEN_IP_CONF_KEY                  "LISTEN_IP"
 #define PC_API_PORT_CONF_KEY                "PC_API_PORT"
 #define APP_API_PORT_CONF_KEY               "APP_API_PORT"
+#define KEEPALIVE_ENABLE_KEY                "KEEPALIVE"
 
 char g_LISTEN_IP[MAX_FILE_OR_PROP_LEN_NAME] = "0.0.0.0";
 char g_PAYLOAD_CONTROLLER_IP[MAX_FILE_OR_PROP_LEN_NAME] = "127.0.0.1";
@@ -41,7 +42,8 @@ unsigned short g_PC_GRPC_SERVER_PORT = 50051;
 char g_PC_GRPC_SERVER_PORT_STR[MAX_FILE_OR_PROP_LEN_NAME] = "50051";
 unsigned short g_PA_GRPC_SERVER_PORT = 50053;
 char g_PA_GRPC_SERVER_PORT_STR[MAX_FILE_OR_PROP_LEN_NAME] = "50053";
-char g_SSL_ENABLE = '1';       
+char g_SSL_ENABLE = '1';              // SSL is enabled by default
+char g_KEEPALIVE_ENABLE = '0';        // Keepalive is disabled by default
 
 char g_PC_GRPC_LISTEN_ENDPOINT[MAX_FILE_OR_PROP_LEN_NAME] = "0.0.0.0:50051";
 char g_PC_GRPC_CONNECT_ENDPOINT[MAX_FILE_OR_PROP_LEN_NAME] = "127.0.0.1:50051";
@@ -121,6 +123,8 @@ static void update_a_conf(char *conf_line)
         strcpy(g_PA_GRPC_SERVER_PORT_STR, a_conf.value);
     } else if (strcmp(a_conf.prop, SSL_ENABLE_KEY) == 0) {
         strcpy(&g_SSL_ENABLE, a_conf.value);
+    } else if (strcmp(a_conf.prop, KEEPALIVE_ENABLE_KEY) == 0) {
+        strcpy(&g_KEEPALIVE_ENABLE, a_conf.value);
     }
 
     return;

--- a/lib/cpp/antaris_sdk_environment.cc
+++ b/lib/cpp/antaris_sdk_environment.cc
@@ -35,6 +35,10 @@ static char g_CONF_JSON[MAX_FILE_OR_PROP_LEN_NAME]="/opt/antaris/app/config.json
 #define APP_API_PORT_CONF_KEY               "APP_API_PORT"
 #define KEEPALIVE_ENABLE_KEY                "KEEPALIVE"
 
+#define KEEPALIVE_TIME_MS                   20000
+#define KEEPALIVE_TIMEOUT_MS                10000
+#define KEEPALIVE_PERMIT_WITHOUT_CALLS      1
+
 char g_LISTEN_IP[MAX_FILE_OR_PROP_LEN_NAME] = "0.0.0.0";
 char g_PAYLOAD_CONTROLLER_IP[MAX_FILE_OR_PROP_LEN_NAME] = "127.0.0.1";
 char g_PAYLOAD_APP_IP[MAX_FILE_OR_PROP_LEN_NAME] = "127.0.0.1";
@@ -43,7 +47,7 @@ char g_PC_GRPC_SERVER_PORT_STR[MAX_FILE_OR_PROP_LEN_NAME] = "50051";
 unsigned short g_PA_GRPC_SERVER_PORT = 50053;
 char g_PA_GRPC_SERVER_PORT_STR[MAX_FILE_OR_PROP_LEN_NAME] = "50053";
 char g_SSL_ENABLE = '1';              // SSL is enabled by default
-char g_KEEPALIVE_ENABLE = '0';        // Keepalive is disabled by default
+char g_KEEPALIVE_ENABLE = '1';        // Keepalive is disabled by default
 
 char g_PC_GRPC_LISTEN_ENDPOINT[MAX_FILE_OR_PROP_LEN_NAME] = "0.0.0.0:50051";
 char g_PC_GRPC_CONNECT_ENDPOINT[MAX_FILE_OR_PROP_LEN_NAME] = "127.0.0.1:50051";

--- a/lib/python/satos_payload_sdk/antaris_api_client.py
+++ b/lib/python/satos_payload_sdk/antaris_api_client.py
@@ -156,15 +156,10 @@ def api_pa_pc_create_channel_common(secure, callback_func_list):
         pings to be sent even if there are no calls in flight.
     For more details, check: https://github.com/grpc/grpc/blob/master/doc/keepalive.md
     """
-    server_options = [('grpc.keepalive_time_ms', 20000),
-                      ('grpc.keepalive_timeout_ms', 10000),
-                      ('grpc.http2.min_ping_interval_without_data_ms', 5000),
-                      ('grpc.max_connection_idle_ms', 10000),
-                      ('grpc.max_connection_age_ms', 30000),
-                      ('grpc.max_connection_age_grace_ms', 5000),
-                      ('grpc.http2.max_pings_without_data', 5),
-                      ('grpc.keepalive_permit_without_calls', 1)]
-
+    server_options = [("grpc.keepalive_time_ms", 10000), 
+                      ("grpc.keepalive_timeout_ms", 5000), 
+                      ("grpc.keepalive_permit_without_calls", True),
+                      ("grpc.http2.max_ping_strikes", 0)] 
     if api_common.g_SSL_ENABLE == '0':
         print("Creating insecure channel")
         client_handle = antaris_api_pb2_grpc.AntarisapiPayloadControllerStub(grpc.insecure_channel(pc_endpoint, options=server_options))

--- a/lib/python/satos_payload_sdk/antaris_api_client.py
+++ b/lib/python/satos_payload_sdk/antaris_api_client.py
@@ -135,12 +135,40 @@ def api_pa_pc_create_channel_common(secure, callback_func_list):
         print("Callback endpoint {} is not free".format(app_endpoint))
         return None
 
-    print("Starting server")
+    print("Starting server with keepalive")
+
+    """
+    grpc.keepalive_time_ms: The period (in milliseconds) after which a keepalive ping is
+        sent on the transport.
+    grpc.keepalive_timeout_ms: The amount of time (in milliseconds) the sender of the keepalive
+        ping waits for an acknowledgement. If it does not receive an acknowledgment within
+        this time, it will close the connection.
+    grpc.http2.min_ping_interval_without_data_ms: Minimum allowed time (in milliseconds)
+        between a server receiving successive ping frames without sending any data/header frame.
+    grpc.max_connection_idle_ms: Maximum time (in milliseconds) that a channel may have no
+        outstanding rpcs, after which the server will close the connection.
+    grpc.max_connection_age_ms: Maximum time (in milliseconds) that a channel may exist.
+    grpc.max_connection_age_grace_ms: Grace period (in milliseconds) after the channel
+        reaches its max age.
+    grpc.http2.max_pings_without_data: How many pings can the client send before needing to
+        send a data/header frame.
+    grpc.keepalive_permit_without_calls: If set to 1 (0 : false; 1 : true), allows keepalive
+        pings to be sent even if there are no calls in flight.
+    For more details, check: https://github.com/grpc/grpc/blob/master/doc/keepalive.md
+    """
+    server_options = [('grpc.keepalive_time_ms', 20000),
+                      ('grpc.keepalive_timeout_ms', 10000),
+                      ('grpc.http2.min_ping_interval_without_data_ms', 5000),
+                      ('grpc.max_connection_idle_ms', 10000),
+                      ('grpc.max_connection_age_ms', 30000),
+                      ('grpc.max_connection_age_grace_ms', 5000),
+                      ('grpc.http2.max_pings_without_data', 5),
+                      ('grpc.keepalive_permit_without_calls', 1)]
 
     if api_common.g_SSL_ENABLE == '0':
         print("Creating insecure channel")
-        client_handle = antaris_api_pb2_grpc.AntarisapiPayloadControllerStub(grpc.insecure_channel(pc_endpoint))
-        server_handle =  grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+        client_handle = antaris_api_pb2_grpc.AntarisapiPayloadControllerStub(grpc.insecure_channel(pc_endpoint, options=server_options))
+        server_handle =  grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=server_options)
         server_handle.add_insecure_port(app_endpoint)
     else:
         print("SSL is enabled in sdk_env.conf file, creating secure channel")
@@ -151,10 +179,10 @@ def api_pa_pc_create_channel_common(secure, callback_func_list):
             quit()
 
         credentials = grpc.ssl_channel_credentials(root_certs)
-        channel = grpc.secure_channel( pc_endpoint , credentials)
+        channel = grpc.secure_channel( pc_endpoint , credentials, options=server_options)
         client_handle = antaris_api_pb2_grpc.AntarisapiPayloadControllerStub(channel)
 
-        server_handle =  grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+        server_handle =  grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=server_options)
 
         print("Creating secure channel")
         try :

--- a/lib/python/satos_payload_sdk/antaris_api_common.py
+++ b/lib/python/satos_payload_sdk/antaris_api_common.py
@@ -26,6 +26,7 @@ g_PC_GRPC_SERVER_PORT_STR=None
 g_PA_GRPC_SERVER_PORT=None
 g_PA_GRPC_SERVER_PORT_STR =None
 g_SSL_ENABLE=None
+g_KEEPALIVE_ENABLE=None
 
 def init_vars():
     global g_LISTEN_IP
@@ -35,11 +36,13 @@ def init_vars():
     global g_PA_GRPC_SERVER_PORT
     global g_PA_GRPC_SERVER_PORT_STR
     global g_SSL_ENABLE
+    global g_KEEPALIVE_ENABLE
 
     g_LISTEN_IP=environment.get_conf(environment.g_LISTEN_IP_CONF_KEY)
     g_PAYLOAD_CONTROLLER_IP=environment.get_conf(environment.g_PC_IP_CONF_KEY)
     g_PAYLOAD_APP_IP=environment.get_conf(environment.g_APP_IP_CONF_KEY)
     g_SSL_ENABLE=environment.get_conf(environment.g_SSL_ENABLE_KEY)
+    g_KEEPALIVE_ENABLE=environment.get_conf(environment.g_KEEPALIVE_ENABLE_KEY)
     g_PC_GRPC_SERVER_PORT=environment.get_conf(environment.g_PC_API_PORT_CONF_KEY)
     g_PA_GRPC_SERVER_PORT=environment.get_conf(environment.g_APP_API_PORT_CONF_KEY)
     g_PC_GRPC_SERVER_PORT_STR="{}".format(g_PC_GRPC_SERVER_PORT)

--- a/lib/python/satos_payload_sdk/antaris_sdk_environment.py
+++ b/lib/python/satos_payload_sdk/antaris_sdk_environment.py
@@ -26,9 +26,11 @@ g_APP_IP_CONF_KEY="PAYLOAD_APP_IP"
 g_LISTEN_IP_CONF_KEY="LISTEN_IP"
 g_PC_API_PORT_CONF_KEY="PC_API_PORT"
 g_APP_API_PORT_CONF_KEY="APP_API_PORT"
+g_KEEPALIVE_ENABLE_KEY="KEEPALIVE"
 
 g_default_values = {    g_PC_IP_CONF_KEY: "127.0.0.1",
-                        g_SSL_ENABLE_KEY: "1",                 # SSL is enabled by default
+                        g_SSL_ENABLE_KEY: "1",                     # SSL is enabled by default
+                        g_KEEPALIVE_ENABLE_KEY: "1",               # Keepalive is enabled by default
                         g_APP_IP_CONF_KEY: "127.0.0.1",
                         g_LISTEN_IP_CONF_KEY: "0.0.0.0",
                         g_PC_API_PORT_CONF_KEY: "50051",


### PR DESCRIPTION
Python and cpp code is implemented.
Functionality = 
1. Remote client application should send keepalive message after predefined period.
2. This will keep connection between ATMOS TT and remote payload active.
3. Otherwise load balancer on ATMOS TT side can disconnect the connection after idle period of 4 minutes

Note : 
1. cpp application is not tested and hence cpp keepalive code is disabled by default
2. Python client side application is tested