### PR TITLE
fix: fix buffer overflow in app <> peer copy functions

### DIFF
--- a/lib/cpp/antaris_api_common.cc
+++ b/lib/cpp/antaris_api_common.cc
@@ -42,7 +42,7 @@ using grpc::Status;
 
 void app_to_peer_UINT16(void *ptr_src_app, void *ptr_dst_peer)
 {
-    *(INT32 *)ptr_dst_peer = *(UINT16 *)ptr_src_app;
+    *(UINT32 *)ptr_dst_peer = *(UINT16 *)ptr_src_app;
 }
 
 void peer_to_app_UINT16(void *ptr_src_peer, void *ptr_dst_app)
@@ -62,7 +62,7 @@ void peer_to_app_UINT32(void *ptr_src_peer, void *ptr_dst_app)
 
 void app_to_peer_UINT64(void *ptr_src_app, void *ptr_dst_peer)
 {
-    *(INT64 *)ptr_dst_peer = *(UINT64 *)ptr_src_app;
+    *(UINT64 *)ptr_dst_peer = *(UINT64 *)ptr_src_app;
 }
 
 void peer_to_app_UINT64(void *ptr_src_peer, void *ptr_dst_app)
@@ -90,7 +90,6 @@ void peer_to_app_FLOAT(void *ptr_src_peer, void *ptr_dst_app)
     *(FLOAT *)ptr_dst_app = *(FLOAT *)ptr_src_peer;
 }
 
-
 INT32 is_server_endpoint_available(INT8 *ipv4, UINT16 port)
 {
     struct sockaddr_in ep = {0};
@@ -100,20 +99,23 @@ INT32 is_server_endpoint_available(INT8 *ipv4, UINT16 port)
     ep.sin_family = AF_INET;
     ep.sin_port = htons(port);
 
-    if (0 == inet_aton(ipv4, (struct in_addr *)(&ep.sin_addr))) {
+    if (0 == inet_aton(ipv4, (struct in_addr *)(&ep.sin_addr)))
+    {
         is_good = 0;
         goto done;
     }
 
     s = socket(AF_INET, SOCK_STREAM, 0);
 
-    if (s < 0) {
+    if (s < 0)
+    {
         is_good = 0;
         perror("SOCKET: ");
         goto done;
     }
 
-    if (0 != bind(s, (struct sockaddr *)&ep, sizeof(ep))) {
+    if (0 != bind(s, (struct sockaddr *)&ep, sizeof(ep)))
+    {
         is_good = 0;
         perror("BIND: ");
         goto clean_socket;


### PR DESCRIPTION
All use of `app_to_peer_UINT16`/`app_to_peer_UINT32`/`app_to_peer_UINT64` functions are passed uint and not int, so when building a release built, we get a buffer overflow at runtime.

![Screenshot 2023-09-28 at 18 01 00](https://github.com/antaris-inc/SatOS-Payload-SDK/assets/1479737/5895d635-d870-40dd-812a-d26fb8c1e21c)

This PR addresses that.