### PR TITLE
fix(sdk env): fix duplicate decl of var

### DIFF
--- a/lib/cpp/antaris_sdk_environment.cc
+++ b/lib/cpp/antaris_sdk_environment.cc
@@ -106,9 +106,8 @@ not_found:
 
 static void update_a_conf(char *conf_line)
 {
-    int8_t length = -1;
     conf_t a_conf = {0};
-    size_t length = 0;
+    size_t length;
 
     parse_a_conf(conf_line, &a_conf);
     length = strnlen(a_conf.value, MAX_IP_OR_PORT_LENGTH);


### PR DESCRIPTION
Fix duplicate declaration compiler error:
```
120.1 [ 27%] Built target paapis_lib
120.4 [ 30%] Building CXX object _deps/antaris-sdk-build/CMakeFiles/antaris_api.dir/lib/cpp/antaris_sdk_environment.cc.o
120.9 [ 32%] Linking CXX static library ../../../lib/libsignals.a
121.3 /code/build/_deps/antaris-sdk-src/lib/cpp/antaris_sdk_environment.cc: In function 'void update_a_conf(char*)':
121.3 /code/build/_deps/antaris-sdk-src/lib/cpp/antaris_sdk_environment.cc:111:12: error: conflicting declaration 'size_t length'
121.3   111 |     size_t length = 0;
121.3       |            ^~~~~~
121.3 /code/build/_deps/antaris-sdk-src/lib/cpp/antaris_sdk_environment.cc:109:12: note: previous declaration as 'int8_t length'
121.3   109 |     int8_t length = -1;
121.3       |            ^~~~~~
121.5 make[2]: *** [_deps/antaris-sdk-build/CMakeFiles/antaris_api.dir/build.make:118: _deps/antaris-sdk-build/CMakeFiles/antaris_api.dir/lib/cpp/antaris_sdk_environment.cc.o] Error 1
```
