### PR TITLE
fix: fix buffer overflow in app <> peer copy functions

### DIFF
--- a/lib/cpp/antaris_api_common.cc
+++ b/lib/cpp/antaris_api_common.cc
@@ -42,7 +42,7 @@ using grpc::Status;
 
 void app_to_peer_UINT16(void *ptr_src_app, void *ptr_dst_peer)
 {
-    *(INT32 *)ptr_dst_peer = *(UINT16 *)ptr_src_app;
+    *(UINT32 *)ptr_dst_peer = *(UINT16 *)ptr_src_app;
 }
 
 void peer_to_app_UINT16(void *ptr_src_peer, void *ptr_dst_app)
@@ -62,7 +62,7 @@ void peer_to_app_UINT32(void *ptr_src_peer, void *ptr_dst_app)
 
 void app_to_peer_UINT64(void *ptr_src_app, void *ptr_dst_peer)
 {
-    *(INT64 *)ptr_dst_peer = *(UINT64 *)ptr_src_app;
+    *(UINT64 *)ptr_dst_peer = *(UINT64 *)ptr_src_app;
 }
 
 void peer_to_app_UINT64(void *ptr_src_peer, void *ptr_dst_app)


### PR DESCRIPTION
Our payload application does not connect to the ACP if we build the release target w/o this change. This is the same as https://github.com/antaris-inc/SatOS-Payload-SDK/pull/25, but I've removed the additional format changes.