### PR TITLE
Added CAN bus support in python lib

### DIFF
--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -145,10 +145,6 @@ class Controller:
 
         # Get Arbitration ID & data
         data = ctx.params
-        if data == "":
-            logger.info("Using default Arbitration ID & data, as input string is empty")
-            data = "0x123 0x11,0x12,0x13,0x14,0x15,0x16,0x17"
-
         parts = data.split()
 
         if len(parts) != 2:

--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -176,30 +176,29 @@ class Controller:
         
         # Defining limits for data send and receive
         send_msg_limit = 10
-        start_msg_read = 5
-        loop_reset_limit = 12
 
         loopCounter = 0
 
         # Main loop to send CAN messages
-        while loopCounter < loop_reset_limit:
+        logger.info("Sending data in CAN bus")
+        while loopCounter < send_msg_limit:
             loopCounter = loopCounter + 1
+            arb_id = arb_id + 1
+            api_can.api_pa_pc_send_can_message(channel, arb_id, data_bytes)
+            time.sleep(1)
 
-            if loopCounter < send_msg_limit:
-                # Example message: arbitration_id=0x123, data=[0x01, 0x02, 0x03, loopCounter]
-                api_can.api_pa_pc_send_can_message(channel, arb_id, data_bytes)
+        logger.info("Data send = ", api_can.api_pa_pc_get_can_message_received_count())
 
-            if loopCounter >  start_msg_read:
-                print("Start reading")
-                while api_can.api_pa_pc_get_can_message_received_count() > 0: 
-                    received_data = api_can.api_pa_pc_read_can_data()
-                    if received_data != g_GPIO_ERROR:
-                        print("received data =", received_data)
-                    else:
-                        print("Error in receiving data")
-                print("Completed reading")
+        while api_can.api_pa_pc_get_can_message_received_count() > 0: 
+            received_data = api_can.api_pa_pc_read_can_data()
+            if received_data != g_GPIO_ERROR:
+                print("received data =", received_data)
+            else:
+                print("Error in receiving data")
+        
+        logger.info("Completed reading")
 
-            time.sleep(1) 
+             
 
         return 
     

--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -194,8 +194,6 @@ class Controller:
         
         logger.info("Completed reading")
 
-             
-
         return 
     
 def new():
@@ -215,7 +213,7 @@ def new():
     app.mount_sequence("UARTLoopback", ctl.handle_uart_loopback)
     app.mount_sequence("StageFile",ctl.handle_stage_filedownload)
     app.mount_sequence("PowerControl", ctl.handle_power_control)
-    app.mount_sequence("TestCanBus", ctl.handle_test_can_bus)
+    app.mount_sequence("TestCANBus", ctl.handle_test_can_bus)
     return app
 
 def set_payload_values(payload_app):

--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -187,7 +187,7 @@ class Controller:
 
             if loopCounter < send_msg_limit:
                 # Example message: arbitration_id=0x123, data=[0x01, 0x02, 0x03, loopCounter]
-                api_can.api_pa_pc_send_can_message(channel, 0x123, [0x01, 0x02, 0x03, loopCounter])
+                api_can.api_pa_pc_send_can_message(channel, arb_id, data_bytes)
 
             if loopCounter >  start_msg_read:
                 print("Start reading")

--- a/examples/config.json
+++ b/examples/config.json
@@ -24,6 +24,11 @@
             "UART_PORT_COUNT": "2",
             "Device_Path_0": "/dev/ttyUSB0",
             "Device_Path_1": "/dev/ttyUSB1"
+        },
+        "CAN": {
+            "CAN_PORT_COUNT": "1",
+            "CAN_Bus_Path_0": "can1",
+            "CAN_Bus_Path_1": "can0"
         }
     },
     "Network" : {

--- a/images/app-cpp/Dockerfile
+++ b/images/app-cpp/Dockerfile
@@ -29,6 +29,7 @@ RUN pip install pylibftdi
 RUN apt install -y libftdi1
 RUN python3 -m pip install pyserial
 RUN python3 -m pip install azure-storage-file-share
+RUN python3 -m pip install python-can
 
 RUN mkdir /stage
 COPY dist/satos-payload-sdk-cpp.deb /stage

--- a/images/app-python/Dockerfile
+++ b/images/app-python/Dockerfile
@@ -28,6 +28,7 @@ RUN python3 -m pip install --upgrade pip
 # This is required for GPIO and UART access using FTDI
 RUN apt install -y libftdi1
 RUN python3 -m pip install pyserial
+RUN python3 -m pip install python-can
 
 RUN mkdir /stage
 COPY dist/satos_payload_sdk-*.whl /stage

--- a/images/app-python/Dockerfile
+++ b/images/app-python/Dockerfile
@@ -28,6 +28,8 @@ RUN python3 -m pip install --upgrade pip
 # This is required for GPIO and UART access using FTDI
 RUN apt install -y libftdi1
 RUN python3 -m pip install pyserial
+
+#This is required for CAN bus read/write
 RUN python3 -m pip install python-can
 
 RUN mkdir /stage

--- a/lib/python/satos_payload_sdk/antaris_api_can.py
+++ b/lib/python/satos_payload_sdk/antaris_api_can.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2022 Antaris, Inc.
+#   Copyright 2024 Antaris, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -111,42 +111,3 @@ def api_pa_pc_send_can_message(channel, arbitration_id, data):
 
 def api_pa_pc_get_can_message_received_count():
     return len(data_array)
-
-if __name__ == "__main__":
-    send_msg_limit = 10
-    start_msg_read = 5
-    loop_reset_limit = 12
-
-    loopCounter = 0
-
-     # Get CAN devices from configuration
-    can_obj = api_pa_pc_get_can_dev()
-
-    # Define the CAN channel to use (assuming the first device)
-    channel = can_obj.can_dev[0]
-
-    # Start a thread to continuously receive CAN messages
-    api_pa_pc_start_can_receiver_thread(channel)
-
-    # Main loop to send CAN messages
-    while True:
-        loopCounter = loopCounter + 1
-
-        if loopCounter < send_msg_limit:
-            # Example message: arbitration_id=0x123, data=[0x01, 0x02, 0x03, loopCounter]
-            api_pa_pc_send_can_message(channel, 0x123, [0x01, 0x02, 0x03, loopCounter])
-
-        if loopCounter >  start_msg_read:
-            print("Start reading")
-            while api_pa_pc_get_can_message_received_count() > 0: 
-                received_data = api_pa_pc_read_can_data()
-                if received_data != g_GPIO_ERROR:
-                    print("received data =", received_data)
-                else:
-                    print("Error in receiving data")
-            print("Completed reading")
-
-        if loopCounter == loop_reset_limit:
-            loopCounter = 0
-
-        time.sleep(1) 

--- a/lib/python/satos_payload_sdk/antaris_api_can.py
+++ b/lib/python/satos_payload_sdk/antaris_api_can.py
@@ -1,0 +1,152 @@
+#
+#   Copyright 2022 Antaris, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# This file assumes that, env.json file is present at /opt/antaris/app
+# location. The sample file is checked-in in conf directory
+import can
+import threading
+import time
+import json
+
+g_JSON_Key_IO_Access = "IO_Access"
+g_JSON_Key_CAN = "CAN"
+g_JSON_Key_Device_Count = "CAN_PORT_COUNT"
+g_JSON_Key_CAN_Device_Path = "CAN_Bus_Path_"
+
+# Read config info
+jsonfile = open('/opt/antaris/app/config.json', 'r')
+
+g_GPIO_ERROR = -1
+
+# threading lock
+threadLock = -1
+data_array = []
+
+# returns JSON object as a dictionary
+jsfile_data = json.load(jsonfile)
+
+class CAN:
+    def __init__(self, port_count, can_dev):
+        self.can_port_count = port_count
+        self.can_dev = can_dev
+
+def api_pa_pc_get_can_dev():
+    g_total_can_port = jsfile_data[g_JSON_Key_IO_Access][g_JSON_Key_CAN][g_JSON_Key_Device_Count]
+    can_dev = []
+
+    i = 0
+    for i in range(int(g_total_can_port)):
+        key = g_JSON_Key_CAN_Device_Path+str(i)
+        element = jsfile_data[g_JSON_Key_IO_Access][g_JSON_Key_CAN][key]
+        can_dev.append(element)
+
+    canObj = CAN(g_total_can_port, can_dev)
+    return canObj
+
+def api_pa_pc_receive_can_message(channel, data_array, lock):
+    try:
+        # Initialize a CAN bus interface
+        bus = can.interface.Bus(channel=channel, bustype='socketcan')
+
+        # Continuously receive CAN messages
+        while True:
+            # Receive a CAN message
+            message = bus.recv(timeout=1)
+            if message is not None:
+                with lock:
+                    data_array.append(message)  # Append the received message to the data array
+
+    except can.CanError as e:
+        print("Error receiving message:", e)
+        return g_GPIO_ERROR
+    
+    finally:
+        # Clean up and close the bus
+        bus.shutdown()
+
+def api_pa_pc_read_can_data():
+    with threadLock:
+        if data_array:
+            data = data_array.pop(0)
+            return data 
+        else:
+            return g_GPIO_ERROR
+
+def api_pa_pc_start_can_receiver_thread(channel):
+    # Create shared data array and lock
+    threadLock = threading.Lock()
+    receive_thread = threading.Thread(target=api_pa_pc_receive_can_message, args=(channel, data_array, threadLock))
+    receive_thread.daemon = True
+    receive_thread.start()
+
+def api_pa_pc_send_can_message(channel, arbitration_id, data):
+    try:
+        # Initialize a CAN bus interface
+        bus = can.interface.Bus(channel=channel, bustype='socketcan')
+
+        # Send a CAN message
+        message = can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=False)
+        bus.send(message)
+        return 0
+
+    except can.CanError as e:
+        print("Error sending message:", e)
+        return g_GPIO_ERROR
+    
+    finally:
+        # Clean up and close the bus
+        bus.shutdown()
+
+def api_pa_pc_get_can_message_received_count():
+    return len(data_array)
+
+if __name__ == "__main__":
+    send_msg_limit = 10
+    start_msg_read = 5
+    loop_reset_limit = 12
+
+    loopCounter = 0
+
+     # Get CAN devices from configuration
+    can_obj = api_pa_pc_get_can_dev()
+
+    # Define the CAN channel to use (assuming the first device)
+    channel = can_obj.can_dev[0]
+
+    # Start a thread to continuously receive CAN messages
+    api_pa_pc_start_can_receiver_thread(channel)
+
+    # Main loop to send CAN messages
+    while True:
+        loopCounter = loopCounter + 1
+
+        if loopCounter < send_msg_limit:
+            # Example message: arbitration_id=0x123, data=[0x01, 0x02, 0x03, loopCounter]
+            api_pa_pc_send_can_message(channel, 0x123, [0x01, 0x02, 0x03, loopCounter])
+
+        if loopCounter >  start_msg_read:
+            print("Start reading")
+            while api_pa_pc_get_can_message_received_count() > 0: 
+                received_data = api_pa_pc_read_can_data()
+                if received_data != g_GPIO_ERROR:
+                    print("received data =", received_data)
+                else:
+                    print("Error in receiving data")
+            print("Completed reading")
+
+        if loopCounter == loop_reset_limit:
+            loopCounter = 0
+
+        time.sleep(1) 


### PR DESCRIPTION
Standalone CAN bus program is tested on QA7 board.
The code functionalities:
      1. CAN message receive thread is running on user defined can port. This thread pushes received data in a buffer.
      2.  User can call "api_pa_pc_read_can_data" function to read single data.
      3. To send data, user can use "api_pa_pc_send_can_message" function