### PR TITLE
Enablling CAN Communication via raspberry pi

### DIFF
--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -20,7 +20,6 @@ import os
 import sys
 import time
 import serial
-import threading
 
 from satos_payload_sdk import app_framework
 from satos_payload_sdk import antaris_api_gpio as api_gpio

--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import serial
+import threading
 
 from satos_payload_sdk import app_framework
 from satos_payload_sdk import antaris_api_gpio as api_gpio
@@ -165,7 +166,7 @@ class Controller:
 
         # Define the CAN channel to use (assuming the first device)
         channel = canInfo.can_dev[0]
-        logger.info("Starting CAN receiver port", channel)
+        logger.info("Starting CAN receiver port %s", channel)
 
         # Starting CAN received thread
         api_can.api_pa_pc_start_can_receiver_thread(channel)
@@ -183,7 +184,7 @@ class Controller:
             api_can.api_pa_pc_send_can_message(channel, arb_id, data_bytes)
             time.sleep(1)
 
-        logger.info("Data send = ", api_can.api_pa_pc_get_can_message_received_count())
+        logger.info("Data send = %d", api_can.api_pa_pc_get_can_message_received_count())
 
         while api_can.api_pa_pc_get_can_message_received_count() > 0: 
             received_data = api_can.api_pa_pc_read_can_data()

--- a/lib/python/satos_payload_sdk/antaris_api_can.py
+++ b/lib/python/satos_payload_sdk/antaris_api_can.py
@@ -33,81 +33,87 @@ g_GPIO_ERROR = -1
 # threading lock
 threadLock = -1
 data_array = []
+canReceiveThreadstarted = False
 
 # returns JSON object as a dictionary
 jsfile_data = json.load(jsonfile)
 
 class CAN:
-    def __init__(self, port_count, can_dev):
-        self.can_port_count = port_count
-        self.can_dev = can_dev
+   def __init__(self, port_count, can_dev):
+       self.can_port_count = port_count
+       self.can_dev = can_dev
 
 def api_pa_pc_get_can_dev():
-    g_total_can_port = jsfile_data[g_JSON_Key_IO_Access][g_JSON_Key_CAN][g_JSON_Key_Device_Count]
-    can_dev = []
+   g_total_can_port = jsfile_data[g_JSON_Key_IO_Access][g_JSON_Key_CAN][g_JSON_Key_Device_Count]
+   can_dev = []
 
-    i = 0
-    for i in range(int(g_total_can_port)):
-        key = g_JSON_Key_CAN_Device_Path+str(i)
-        element = jsfile_data[g_JSON_Key_IO_Access][g_JSON_Key_CAN][key]
-        can_dev.append(element)
+   i = 0
+   for i in range(int(g_total_can_port)):
+       key = g_JSON_Key_CAN_Device_Path+str(i)
+       element = jsfile_data[g_JSON_Key_IO_Access][g_JSON_Key_CAN][key]
+       can_dev.append(element)
 
-    canObj = CAN(g_total_can_port, can_dev)
-    return canObj
+   canObj = CAN(g_total_can_port, can_dev)
+   return canObj
 
 def api_pa_pc_receive_can_message(channel, data_array, lock):
-    try:
-        # Initialize a CAN bus interface
-        bus = can.interface.Bus(channel=channel, bustype='socketcan')
+   try:
+       # Initialize a CAN bus interface
+       bus = can.interface.Bus(channel=channel, bustype='socketcan')
 
-        # Continuously receive CAN messages
-        while True:
-            # Receive a CAN message
-            message = bus.recv(timeout=1)
-            if message is not None:
-                with lock:
-                    data_array.append(message)  # Append the received message to the data array
+       # Continuously receive CAN messages
+       while True:
+           # Receive a CAN message
+           message = bus.recv(timeout=1)
+           if message is not None:
+               with lock:
+                   data_array.append(message)  # Append the received message to the data array
 
-    except can.CanError as e:
-        print("Error receiving message:", e)
-        return g_GPIO_ERROR
-    
-    finally:
-        # Clean up and close the bus
-        bus.shutdown()
+   except can.CanError as e:
+       print("Error receiving message:", e)
+       return g_GPIO_ERROR
+   
+   finally:
+       # Clean up and close the bus
+       bus.shutdown()
 
 def api_pa_pc_read_can_data():
-    with threadLock:
-        if data_array:
-            data = data_array.pop(0)
-            return data 
-        else:
-            return g_GPIO_ERROR
+   with threadLock:
+       if data_array:
+           data = data_array.pop(0)
+           return data
+       else:
+           return g_GPIO_ERROR
 
 def api_pa_pc_start_can_receiver_thread(channel):
-    # Create shared data array and lock
-    threadLock = threading.Lock()
-    receive_thread = threading.Thread(target=api_pa_pc_receive_can_message, args=(channel, data_array, threadLock))
-    receive_thread.daemon = True
-    receive_thread.start()
+   # Create shared data array and lock
+   global threadLock, canReceiveThreadstarted
+   if not canReceiveThreadstarted:
+       threadLock = threading.Lock()
+       receive_thread = threading.Thread(target=api_pa_pc_receive_can_message, args=(channel, data_array, threadLock))
+       receive_thread.daemon = True
+       receive_thread.start()
+       canReceiveThreadstarted= True
+   else:
+       print("Receive Thread Already Running")
 
 def api_pa_pc_send_can_message(channel, arbitration_id, data):
-    try:
-        # Initialize a CAN bus interface
-        bus = can.interface.Bus(channel=channel, bustype='socketcan')
+   try:
+       # Initialize a CAN bus interface
+       bus = can.interface.Bus(channel=channel, bustype='socketcan')
 
-        # Send a CAN message
-        message = can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=False)
-        bus.send(message)
-        return 0
+       # Send a CAN message
+       message = can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=False)
+       bus.send(message)
+       return 0
 
-    except can.CanError as e:
-        print("Error sending message:", e)
-        return g_GPIO_ERROR
-    
-    finally:
-        # Clean up and close the bus
-        bus.shutdown()
+   except can.CanError as e:
+       print("Error sending message:", e)
+       return g_GPIO_ERROR
+   
+   finally:
+       # Clean up and close the bus
+       bus.shutdown()
 
 def api_pa_pc_get_can_message_received_count():
-    return len(data_array)
+   return len(data_array)


### PR DESCRIPTION
Summary of the process -
we here use raspberry pi as a payload server. and a laptop as payload device. first mount can-hat to raspberry pi to enable can interface and use a usb to can adaptor to connect it with payload device. then used antaris cloud platform to built the remote configuration of payload and successfully test it by sending commands like Hello World and TestCANBus from the platform.
The required base image for building this configuration is amd based and the raspberry pi uses amd based. so it is needed to do some additional configuration before testing it on raspberry pi.
