### PR TITLE
Independent C++ Payload App Build Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 __pycache__/
 .tox/
 *.o
+*.a
+**.zip
+**.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ python_package:
 	./tools/package-python-lib.sh
 
 cpp_package:
+	./tools/package_grpc_build.sh
 	./tools/package-cpp-lib.sh
 
 docs:

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ python_package:
 	./tools/package-python-lib.sh
 
 cpp_package:
-	./tools/package_grpc_build.sh
+	./tools/package-grpc-lib.sh
 	./tools/package-cpp-lib.sh
 
 docs:

--- a/examples/app-cpp/.dockerignore
+++ b/examples/app-cpp/.dockerignore
@@ -1,0 +1,17 @@
+# Ignore Git metadata
+.git/
+.gitignore
+
+# Ignore build artifacts
+build/
+out/
+*.o
+*.so
+
+# Ignore system files
+*.log
+.DS_Store
+
+# Project specific
+*.zip
+payload_app # Don't copy a prebuilt binary.

--- a/examples/app-cpp/Dockerfile
+++ b/examples/app-cpp/Dockerfile
@@ -12,8 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/antaris-inc/satos-payload-app-cpp:stable
+# Stage 1: Build dependencies.
+FROM quay.io/antaris-inc/satos-payload-app-cpp:stable AS dependencies
+RUN apt update && apt install -y build-essential
 
-ADD payload_app /opt/antaris/app/payload_app
-ADD entrypoint.sh /opt/antaris/app/entrypoint.sh
-RUN mkdir -p /opt/antaris/outbound -p /opt/antaris/inbound
+# Stage 2: Build your payload app.
+FROM dependencies AS builder
+WORKDIR /workspace
+COPY . .
+RUN make
+
+# Stage 3: Runtime image
+FROM quay.io/antaris-inc/satos-payload-app-cpp:stable
+COPY --from=builder /workspace/payload_app /opt/antaris/app/payload_app
+COPY entrypoint.sh /opt/antaris/app/entrypoint.sh
+RUN mkdir -p /opt/antaris/outbound /opt/antaris/inbound

--- a/examples/app-cpp/Makefile
+++ b/examples/app-cpp/Makefile
@@ -1,0 +1,37 @@
+
+####################### Antaris dependencies ####################################
+GRPC_CPP_ADDITIONAL_LIBS = -L /usr/local/antaris/grpc/lib64/ \
+			   -L /usr/local/antaris/grpc/lib/ \
+			   -lprotobuf -lgrpc++ -lgrpc -lgrpc++_reflection \
+			   -lgpr -lupb -labsl_bad_optional_access -labsl_cord \
+			   -labsl_raw_logging_internal -labsl_cordz_info \
+			   -labsl_cordz_handle -labsl_base -labsl_spinlock_wait \
+			   -labsl_synchronization -labsl_base -labsl_malloc_internal \
+			   -labsl_synchronization -labsl_symbolize \
+			   -labsl_debugging_internal -labsl_demangle_internal \
+			   -labsl_time -labsl_time_zone -labsl_int128 \
+			   -labsl_graphcycles_internal -labsl_stacktrace \
+			   -labsl_debugging_internal -labsl_cordz_functions \
+			   -labsl_exponential_biased -labsl_cord_internal \
+			   -labsl_throw_delegate -labsl_strings -labsl_strings_internal \
+			   -labsl_status -labsl_str_format_internal -labsl_statusor \
+			   -labsl_bad_variant_access -lre2 -lcares \
+			   -laddress_sorting -labsl_hash -labsl_city \
+			   -labsl_low_level_hash -labsl_random_internal_randen_slow \
+			   -labsl_random_internal_platform \
+			   -labsl_random_internal_randen_hwaes_impl \
+			   -labsl_random_internal_pool_urbg \
+			   -labsl_random_internal_seed_material \
+			   -labsl_random_seed_gen_exception \
+			   -labsl_random_internal_randen \
+			   -labsl_random_internal_randen_hwaes -lpthread -lssl -lcrypto -lz
+GRPC_CPP_ADDITIONAL_INCLUDES = -I /usr/local/antaris/grpc/include/
+INCLUDES = -I /usr/local/include/ -I /usr/lib/antaris/include -I /usr/lib/antaris/gen $(GRPC_CPP_ADDITIONAL_INCLUDES)
+LIBS = -L /usr/lib/antaris -lantaris_api -lpthread -lpython3.10 $(GRPC_CPP_ADDITIONAL_LIBS)
+############################################################################
+
+# Payload Application specific build flow:
+payload_app: payload_app.cc
+	g++ -o payload_app payload_app.cc $(INCLUDES) $(LIBS)
+clean:
+	rm -f payload_app

--- a/examples/app-cpp/README.md
+++ b/examples/app-cpp/README.md
@@ -1,36 +1,27 @@
 # Example C++ Payload Application
 
-This directory contains an example Payload Application using the C++.
+This directory contains an example Payload Application using the C++ API.
 This is not production-ready code, but it is useful for learning how the platform functions.
-
-NOTE: All the cpp files need to have .cc extention only.
-
-
-## Build Cpp application
-
-To build application in examples/app-cpp , go to SatOS_Payload_SDK parent directory and run `make build_cpp`.
-
-`make build_cpp` will instantiate a build environment container and compile cpp application present at examples/app-cpp. For other locations please refer the main README iniside SatOS-Payload-SDK.
-
-```
-cd ../.. 
-make build_cpp
-```
 
 ## Quickstart
 
 In the Antaris Cloud Platform, create a TrueTwin Satellite with a remote payload and download the associated config.
 Place that downloaded zip file in this directory.
 
-Build the app using the following command:
+Build the C++ app using the following steps:
 
-```
+```bash
+cd examples/app-cpp
+
+# Builds your standalone application first 
 docker build --platform=linux/amd64 -t satos-payload-example-app-cpp .
 ```
 
-Next, we can run the application in a container. The command below assumes that `$CONFIG` is set to the name of the config file (zip) you downloaded from Antaris Cloud Platform. The file must be located in your current working directory:
+Next, we can run the payload application in the container. The command below assumes that `$CONFIG` is set to the name of the config file (zip) you downloaded from Antaris Cloud Platform. The file must be located in your current working directory:
 
-```
+```bash
+CONFIG=your_remote_config_from_acp.zip
+
 docker run --platform=linux/amd64 -e CONFIG=$CONFIG --privileged -v $(pwd):/workspace -it satos-payload-example-app-cpp
 ```
 

--- a/images/app-cpp/Dockerfile
+++ b/images/app-cpp/Dockerfile
@@ -34,6 +34,10 @@ RUN python3 -m pip install python-can
 RUN mkdir /stage
 COPY dist/satos-payload-sdk-cpp.deb /stage
 RUN apt update && apt install -y /stage/satos-payload-sdk-cpp.deb
+
+COPY dist/grpc-dev.deb /stage
+RUN apt install -y pkg-config /stage/grpc-dev.deb
+
 RUN rm -fr /stage
 
 

--- a/tools/package-cpp-lib.sh
+++ b/tools/package-cpp-lib.sh
@@ -40,6 +40,9 @@ cp $BUILD_ROOT/lib/cpp/include/antaris_api_internal.h $DEB_OUTPUT_DIR/lib/antari
 cp $BUILD_ROOT/lib/cpp/include/antaris_cpp_standard_includes.h $DEB_OUTPUT_DIR/lib/antaris/include
 cp $BUILD_ROOT/lib/cpp/include/antaris_pc_to_app_api.h $DEB_OUTPUT_DIR/lib/antaris/include
 cp $BUILD_ROOT/lib/cpp/include/antaris_sdk_environment.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_api_gpio.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/lib/cpp/include/antaris_api_pyfunctions.h $DEB_OUTPUT_DIR/lib/antaris/include
+cp $BUILD_ROOT/vendor/cJSON/interface/cJSON.h $DEB_OUTPUT_DIR/lib/antaris/include
 
 
 # Set package metadata and build

--- a/tools/package-grpc-lib.sh
+++ b/tools/package-grpc-lib.sh
@@ -16,10 +16,6 @@ mkdir -p "$DEB_OUTPUT_DIR" "$DEB_OUTPUT_DIR/DEBIAN"
 mkdir -p "$DEB_OUTPUT_DIR/usr/local/antaris/grpc"
 cp -r "$GRPC_INSTALL_DIR/"* "$DEB_OUTPUT_DIR/usr/local/antaris/grpc"
 
-# Copy protoc binaries
-mkdir -p "$DEB_OUTPUT_DIR/usr/local/antaris/protoc"
-cp -r "$ANTARIS_INSTALLATIONS_PATH/"* "$DEB_OUTPUT_DIR/usr/local/antaris/protoc"
-
 # Set package metadata and build
 cat << EOM > $DEB_OUTPUT_DIR/DEBIAN/control
 Package: $DEB_NAME

--- a/tools/package_grpc_build.sh
+++ b/tools/package_grpc_build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+# Copyright 2024 Your Name/Organization
+
+DEB_NAME="grpc-dev"
+BUILD_ROOT=$(pwd)
+VERSION="1.46.3-custom" # Adjust version as needed, should match sdk_tools' version. 
+OUTPUT_DIR="$BUILD_ROOT/dist"
+DEB_OUTPUT_DIR="$OUTPUT_DIR/$DEB_NAME"
+ANTARIS_INSTALLATIONS_PATH="/usr/local/antaris"
+GRPC_INSTALL_DIR="${ANTARIS_INSTALLATIONS_PATH}/grpc"
+
+mkdir -p "$DEB_OUTPUT_DIR" "$DEB_OUTPUT_DIR/DEBIAN"
+
+# Copy gRPC libraries and headers
+mkdir -p "$DEB_OUTPUT_DIR/usr/local/antaris/grpc"
+cp -r "$GRPC_INSTALL_DIR/"* "$DEB_OUTPUT_DIR/usr/local/antaris/grpc"
+
+# Copy protoc binaries
+mkdir -p "$DEB_OUTPUT_DIR/usr/local/antaris/protoc"
+cp -r "$ANTARIS_INSTALLATIONS_PATH/"* "$DEB_OUTPUT_DIR/usr/local/antaris/protoc"
+
+# Set package metadata and build
+cat << EOM > $DEB_OUTPUT_DIR/DEBIAN/control
+Package: $DEB_NAME
+Version: $VERSION
+Maintainer: antaris
+Architecture: amd64
+Description: gRPC development libraries and headers
+EOM
+
+cd "$OUTPUT_DIR"
+dpkg-deb --build "$DEB_NAME" 
+
+if [ $? -eq 0 ]; then
+    echo "Packaged $DEB_NAME.deb successfully"
+    rm -fr "$DEB_NAME"
+else
+    echo "Packaging $DEB_NAME.deb failed"
+    exit 1
+fi


### PR DESCRIPTION
Hi, 

This PR addresses https://github.com/antaris-inc/SatOS-Payload-SDK/issues/64 to allow building a standalone C++ payload app using only the ```quay.io/antaris-inc/satos-payload-app-cpp:stable``` image. 

For this, I've packaged the gRPC libs that are built from source in the ```sdk-tools``` image into a separate .deb that can be installed later by the ```satos-payload-app-cpp``` image similar to the cpp sdk and agent .debs. I chose to do this to ensure there are no gRPC or protobuf version mismatches at link-time with ```libantaris_api.a```. 

Since I couldn't modify the published C++ image like you do in your CI, I've done the following steps locally. 

```bash
# Build the SDK environment, SDK agent, and cpp libs + headers. 
docker build -f images/sdk-tools/Dockerfile -t quay.io/antaris-inc/satos-payload-sdk-tools .
docker run --platform linux/amd64 -v $PWD:/workspace quay.io/antaris-inc/satos-payload-sdk-tools make api_lib agent_package
docker run --platform linux/amd64 -v $PWD:/workspace quay.io/antaris-inc/satos-payload-sdk-tools make cpp_package

# Build the C++-specific build environment 
docker build -f images/app-cpp/Dockerfile -t [quay.io/antaris-inc/satos-payload-app-cpp](http://quay.io/antaris-inc/satos-payload-app-cpp) .
```

Next, I follow the steps in ```examples/app-cpp/README.md``` to build the sample app. These steps would work outside the repo as well, as it no longer includes the ```make build_cpp``` step which coupled the builds. I've tested that this works with the ACP TrueTwin console as well. 

The example app-cpp's Dockerfile is modified to build the payload_app binary in the container itself, instead of just copying it from the local dir into ```/workspace```. This makes it easier to customise the toolchain and the project directory structure .

One ugly part about this solution is that I've duplicated the linker and include flags from the top-lvl Makefile into the sample app's Makefile. It would be better for a user to be able to query this using a custom pkg-config cmd within the container instead or something, would appreciate your feedback. 
