### PR TITLE
Added code to upload file in json format

### DIFF
--- a/Release_notes.txt
+++ b/Release_notes.txt
@@ -1,3 +1,13 @@
+Date                    : 21 April 2025
+SatOS-SDK Version       : 1.1.3
+Compatible PC Version   : 1.9.5
+
+Release notes:
+    1. Added support for file download on GCP. 
+    2. Since GCP supports a single URL with a filename, the file will be sent in TrueTwin mode as a JSON object containing 
+    two keys:`Name` and `Data`.The original file will be reconstructed by backend test-service before being presented to user.
+
+--------------------------------------------------------------------------------------------------------------------------------
 Date                    : 8 April 2025
 SatOS-SDK Version       : 1.1.3
 Compatible PC Version   : 1.9.5


### PR DESCRIPTION
Since GCP supports a single URL with a filename, the file will be sent in TrueTwin mode as a JSON object containing two keys:`Name` and `Data`.The original file will be reconstructed by backend test-service before being presented to user.