### PR TITLE
Stage file support on GCP cloud, access to GCP bucket

### DIFF
--- a/images/app-cpp/Dockerfile
+++ b/images/app-cpp/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install pylibftdi
 RUN apt install -y libftdi1
 RUN python3 -m pip install pyserial
 RUN python3 -m pip install azure-storage-file-share
-RUN python3 -m pip install google-cloud-storage
+RUN python3 -m pip install requests
 RUN python3 -m pip install python-can
 
 RUN mkdir /stage

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "protobuf ~=4.0",
   "pylibftdi",
   "azure-storage-file-share",
-  "google-cloud-storage",
+  "requests",
 ]
 dynamic = [
   "version"

--- a/lib/python/satos_payload_sdk/antaris_file_download.py
+++ b/lib/python/satos_payload_sdk/antaris_file_download.py
@@ -2,6 +2,7 @@ from azure.storage.fileshare import ShareFileClient
 import logging
 import requests
 from google.oauth2 import service_account
+import os
 
 logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
 logger.setLevel(logging.WARNING)
@@ -24,25 +25,23 @@ class File_Stage():
         file_path_local = g_Outbound_Path_Prefix + self.download_file_params.file_path
         connection_string = self.config_data[g_FTM][g_File_String]
         
-        if "FileEndpoint=" in connection_string :
-
+        if "FileEndpoint=" in connection_string:
             ret = azure_file_upload(file_path_local, connection_string, self.config_data[g_FTM][g_Share_Name], self.file_path_remote)
-        
-        elif "https://storage.googleapis.com" in connection_string:
-
-            ret = gcp_file_upload(connection_string, file_path_local)
-
+            return ret
+        elif "gcs-bucket-upload" in connection_string:
+            return gcp_file_upload(
+                endpoint=connection_string,
+                file_path=file_path_local,
+                gcs_bucket=self.config_data[g_FTM][g_Share_Name],
+                truetwin_dir=self.config_data[g_FTM][g_Truetwin_Dir],
+                filename=self.download_file_params.file_path
+            )
         else:
             raise ValueError("Unsupported connection string format")
-    
-        return ret
-        
+
     def file_download(self):
-        if  self.start_upload():
-            return True
-        else:
-            return False
-        
+        return self.start_upload()
+
 def azure_file_upload(file_name, conn_str, share_name, file_path):
     file_client = ShareFileClient.from_connection_string(conn_str, share_name, file_path)
     try:
@@ -50,16 +49,32 @@ def azure_file_upload(file_name, conn_str, share_name, file_path):
             file_client.upload_file(source_file)
             return True
     except Exception as e:
-        logger.error("Upload  to truetwin failed")
+        logger.error("Upload to truetwin failed")
         logger.error(f"Error message: {str(e)}")
         return False
-    
-def gcp_file_upload(signed_url, local_file_path):
-    """Uploads a file using the signed URL."""
-    with open(local_file_path, "rb") as file:
-        response = requests.put(signed_url, data=file, headers={"Content-Type": "application/octet-stream"})
 
-    if response.status_code == 200:
-        print("✅ File uploaded successfully!")
-    else:
-        print(f"❌ Upload failed. Status: {response.status_code}, Response: {response.text}")
+def gcp_file_upload(endpoint, file_path, gcs_bucket, truetwin_dir, filename):
+    try:
+        with open(file_path, 'rb') as f:
+            files = {
+                'file': (filename, f),
+            }
+            data = {
+                'gcs_bucket': gcs_bucket,
+                'truetwin_dir': truetwin_dir,
+                'filename': filename,
+            }
+            response = requests.post(endpoint, files=files, data=data)
+
+        if response.status_code == 200:
+            return True
+        else:
+            logger.error("Upload to GCS failed")
+            logger.error(f"Status Code: {response.status_code}")
+            logger.error(f"Response Text: {response.text}")
+            return False
+
+    except Exception as e:
+        logger.error("Exception during GCP file upload")
+        logger.error(f"Error message: {str(e)}")
+        return False

--- a/lib/python/satos_payload_sdk/antaris_file_download.py
+++ b/lib/python/satos_payload_sdk/antaris_file_download.py
@@ -6,7 +6,7 @@ import os
 logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
 logger.setLevel(logging.WARNING)
 
-gHttpgHttpOk = 200
+gHttpOk = 200
 g_FTM = "FTM"
 g_File_String = "File_Conn_Str"
 g_Truetwin_Dir = "Truetwin_Dir"
@@ -66,7 +66,7 @@ def gcp_file_upload(endpoint, file_path, gcs_bucket, truetwin_dir, filename):
             }
             response = requests.post(endpoint, files=files, data=data)
 
-        if response.status_code == gHttpgHttpOk:
+        if response.status_code == gHttpOk:
             return True
         else:
             logger.error("Upload to GCS failed")

--- a/lib/python/satos_payload_sdk/antaris_file_download.py
+++ b/lib/python/satos_payload_sdk/antaris_file_download.py
@@ -1,7 +1,6 @@
 from azure.storage.fileshare import ShareFileClient
 import logging
 import requests
-from google.oauth2 import service_account
 import os
 
 logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")

--- a/lib/python/satos_payload_sdk/antaris_file_download.py
+++ b/lib/python/satos_payload_sdk/antaris_file_download.py
@@ -6,6 +6,7 @@ import os
 logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
 logger.setLevel(logging.WARNING)
 
+gHttpgHttpOk = 200
 g_FTM = "FTM"
 g_File_String = "File_Conn_Str"
 g_Truetwin_Dir = "Truetwin_Dir"
@@ -65,7 +66,7 @@ def gcp_file_upload(endpoint, file_path, gcs_bucket, truetwin_dir, filename):
             }
             response = requests.post(endpoint, files=files, data=data)
 
-        if response.status_code == 200:
+        if response.status_code == gHttpgHttpOk:
             return True
         else:
             logger.error("Upload to GCS failed")


### PR DESCRIPTION
This PR extends the File_Stage class to support uploading files to a Google Cloud Storage (GCS) bucket via a pre-signed HTTP endpoint, similar to existing Azure File Share upload functionality.
CC: @rahulbhivare @omkar-sp 