### PR TITLE
retry mechanism to connect payload controller

### DIFF
--- a/examples/app-cpp/payload_app.cc
+++ b/examples/app-cpp/payload_app.cc
@@ -953,12 +953,15 @@ int main(int argc, char *argv[])
     // After registration, simulated PC will ask application to start sequence HelloWorld
 
     printf("All sequences ready to start ...\n");
-
-    while (shutdown_requested == 0) {
+    while (shutdown_requested == 0 && ret == An_SUCCESS) {
         sleep(1);
     }
-
+    if(ret != An_SUCCESS){
+        printf("return code is %d, not able to communicate with server, waiting for sequence cleanups\n",ret);
+    }
+    else{
     printf("Detected shutdown request, waiting for sequence cleanups\n");
+    }
 
     // Wait for all FSM threads to complete
 

--- a/examples/app-cpp/payload_app.cc
+++ b/examples/app-cpp/payload_app.cc
@@ -796,7 +796,7 @@ AntarisReturnCode process_response_gnss_eph_data(GnssEphData *gnss_eph_data)
 
     if(gnss_eph_data->gps_timeout_flag == 1) {
         printf("gps_fix_time: %d",gnss_eph_data->gps_eph_data.gps_fix_time);
-        printf("gps_sys_time: %lld",gnss_eph_data->gps_eph_data.gps_sys_time);
+        printf("gps_sys_time: %llu",gnss_eph_data->gps_eph_data.gps_sys_time);
         OBC_time obc = gnss_eph_data->gps_eph_data.obc_time;
         printf("obc_time : %02d:%02d:%02d.%03d Date: %02d/%02d/%d\n",
                obc.hour, obc.minute, obc.millisecond / 1000,

--- a/lib/cpp/antaris_api_client.cc
+++ b/lib/cpp/antaris_api_client.cc
@@ -50,6 +50,7 @@ extern char g_SSL_ENABLE;
 extern char g_KEEPALIVE_ENABLE;
 
 #define ANTARIS_CALLBACK_GRACE_DELAY    10
+int max_retries = 15;
 
 class PCServiceClient {
  public:
@@ -89,7 +90,6 @@ class PCServiceClient {
         printf("%s: Invoking PC_register api towards PC, sdk version %d.%d.%d\n",
                 __FUNCTION__, ANTARIS_PA_PC_SDK_MAJOR_VERSION, ANTARIS_PA_PC_SDK_MINOR_VERSION,
                 ANTARIS_PA_PC_SDK_PATCH_VERSION);
-        int max_retries = 15;
         AntarisReturnCode tmp_return;
         for(int i = 0; i < max_retries; i++){
             ClientContext context;
@@ -103,7 +103,7 @@ class PCServiceClient {
                 break;
             } else {
                 if(i != max_retries -1){
-                    printf("%s: Got return code OK. retrying again in one seconds\n", __FUNCTION__);
+                    printf("%s: Got return code Not OK. retrying again in one seconds\n", __FUNCTION__);
                     std::this_thread::sleep_for(std::chrono::seconds(1));
                 }
                 tmp_return = An_GENERIC_FAILURE;

--- a/lib/cpp/antaris_api_client.cc
+++ b/lib/cpp/antaris_api_client.cc
@@ -50,7 +50,7 @@ extern char g_SSL_ENABLE;
 extern char g_KEEPALIVE_ENABLE;
 
 #define ANTARIS_CALLBACK_GRACE_DELAY    10
-int max_retries = 15;
+int g_Max_Retries = 15;
 
 class PCServiceClient {
  public:
@@ -91,7 +91,7 @@ class PCServiceClient {
                 __FUNCTION__, ANTARIS_PA_PC_SDK_MAJOR_VERSION, ANTARIS_PA_PC_SDK_MINOR_VERSION,
                 ANTARIS_PA_PC_SDK_PATCH_VERSION);
         AntarisReturnCode tmp_return;
-        for(int i = 0; i < max_retries; i++){
+        for(int i = 0; i < g_Max_Retries; i++){
             ClientContext context;
             context.AddMetadata( COOKIE_STR, this->cookie_str);
             pc_status = stub_->PC_register(&context, pc_req, &pc_response);
@@ -102,7 +102,7 @@ class PCServiceClient {
                 tmp_return = (AntarisReturnCode)(pc_response.return_code());
                 break;
             } else {
-                if(i != max_retries -1){
+                if(i != g_Max_Retries -1){
                     printf("%s: Got return code Not OK. retrying again in one seconds\n", __FUNCTION__);
                     std::this_thread::sleep_for(std::chrono::seconds(1));
                 }

--- a/lib/python/satos_payload_sdk/antaris_api_client.py
+++ b/lib/python/satos_payload_sdk/antaris_api_client.py
@@ -43,7 +43,7 @@ g_KEEPALIVE_TIME_MS = 10000
 g_KEEPALIVE_TIMEOUT_MS = 5000
 g_KEEPALIVE_PERMIT_WITHOUT_CALLS = True
 g_MAX_PING_STRIKES = 0
-max_retries = 15
+g_Max_Retries = 15
 
 class AntarisChannel:
     def __init__(self, grpc_client_handle, grpc_server_handle, pc_to_app_server, is_secure, callback_func_list):
@@ -370,7 +370,7 @@ def api_pa_pc_register(channel, register_params):
     peer_params.sdk_version.minor = sdk_version.ANTARIS_PA_PC_SDK_MINOR_VERSION
     peer_params.sdk_version.patch = sdk_version.ANTARIS_PA_PC_SDK_PATCH_VERSION
     metadata = ((g_COOKIE_STR , "{}".format(channel.jsfile_data[g_COOKIE_STR]) ) , )
-    for attempt in range(1, max_retries + 1):
+    for attempt in range(1,g_Max_Retries + 1):
             try:
                 peer_ret = channel.grpc_client_handle.PC_register(peer_params, metadata=metadata)
 


### PR DESCRIPTION
Remote Payload application is failing to connect to payload controller for the first time. hence adding a retry mechanism. now the application will try to connect payload controller 15 times in the delay of one second before closing the connection.

Jira link - https://antaris.atlassian.net/browse/AT-9914