### PR TITLE
Added api key in gcp upload file process

### DIFF
--- a/examples/app-cpp/payload_app.cc
+++ b/examples/app-cpp/payload_app.cc
@@ -377,7 +377,8 @@ void handle_StageFile(mythreadState_t *mythread)
     FILE *fp = NULL;
     size_t filename_size = 0;
     ReqStageFileDownloadParams download_file_params = {0};
-    
+    char full_file_path[256];
+
     printf("\n Handling sequence: StageFile! \n");
 
     filename_size = strnlen(STAGE_FILE_NAME, MAX_FILE_OR_PROP_LEN_NAME);
@@ -387,18 +388,23 @@ void handle_StageFile(mythreadState_t *mythread)
         goto exit_sequence;
     }
 
+    // Pass just the filename
     sprintf(download_file_params.file_path, "%s", STAGE_FILE_NAME);
-    
+
+    // Create the full path for file creation
+    sprintf(full_file_path, "%s%s", STAGE_FILE_DOWNLOAD_DIR, STAGE_FILE_NAME);
+
     // Adding dummy data in file
-    fp = fopen(download_file_params.file_path, "w");
+    fp = fopen(full_file_path, "w");
     if (fp == NULL) {
-        printf("Error: Can not open file %s. Sequence failed \n", download_file_params.file_path);
+        printf("Error: Can not open file %s. Sequence failed \n", full_file_path);
         goto exit_sequence;
     }
     fprintf(fp, "Testing file download with payload \n");
     fclose(fp);
 
-    printf("Info: Downloading file = %s \n", download_file_params.file_path);
+    printf("Info: Created file at %s \n", full_file_path);
+    printf("Info: Staging file = %s \n", download_file_params.file_path);  // Should print "SampleFile.txt"
 
     download_file_params.file_priority = FILE_DL_PRIORITY_NORMAL;
     download_file_params.file_dl_band = FILE_DL_SBAND;

--- a/lib/cpp/gen/antaris_sdk_version.h
+++ b/lib/cpp/gen/antaris_sdk_version.h
@@ -15,7 +15,7 @@
 #define ANTARIS_SDK_BUILD_USER       "uid=0(root) gid=0(root) groups=0(root)"
 
 
-#define ANTARIS_SDK_BUILD_TIME       "Wed Aug 27 03:56:14 UTC 2025"
+#define ANTARIS_SDK_BUILD_TIME       "Fri Sep 19 08:24:00 UTC 2025"
 
 
 #define ANTARIS_PA_PC_SDK_MAJOR_VERSION             1

--- a/lib/cpp/gen/antaris_sdk_version.h
+++ b/lib/cpp/gen/antaris_sdk_version.h
@@ -15,7 +15,7 @@
 #define ANTARIS_SDK_BUILD_USER       "uid=0(root) gid=0(root) groups=0(root)"
 
 
-#define ANTARIS_SDK_BUILD_TIME       "Wed Aug 27 03:56:14 UTC 2025"
+#define ANTARIS_SDK_BUILD_TIME       "Wed Sep 17 08:54:05 UTC 2025"
 
 
 #define ANTARIS_PA_PC_SDK_MAJOR_VERSION             1

--- a/lib/cpp/gen/antaris_sdk_version.h
+++ b/lib/cpp/gen/antaris_sdk_version.h
@@ -15,7 +15,7 @@
 #define ANTARIS_SDK_BUILD_USER       "uid=0(root) gid=0(root) groups=0(root)"
 
 
-#define ANTARIS_SDK_BUILD_TIME       "Wed Sep 17 08:54:05 UTC 2025"
+#define ANTARIS_SDK_BUILD_TIME       "Wed Aug 27 03:56:14 UTC 2025"
 
 
 #define ANTARIS_PA_PC_SDK_MAJOR_VERSION             1

--- a/lib/cpp/include/antaris_api_pyfunctions.h
+++ b/lib/cpp/include/antaris_api_pyfunctions.h
@@ -37,7 +37,7 @@
 #define AZURE_STRING                   "FileEndpoint="
 #define PYTHON_AZURE_STAGEFILE_MODULE  "azure_file_upload"
 
-#define GCS_STRING                     "gcs-bucket-upload"
+#define GCS_STRING                     "upload-file-to-bucket"
 #define PYTHON_GCS_STAGEFILE_MODULE    "gcp_file_upload"
 
 #define TRUE        1

--- a/lib/python/satos_payload_sdk/antaris_file_download.py
+++ b/lib/python/satos_payload_sdk/antaris_file_download.py
@@ -25,12 +25,12 @@ class File_Stage():
     def start_upload(self):
         file_path_local = g_Outbound_Path_Prefix + self.download_file_params.file_path
         connection_string = self.config_data[g_FTM][g_File_String]
-        api_key = self.config_data[g_FTM][g_API_Key],
+        api_key = self.config_data[g_FTM][g_API_Key]
         
         if "FileEndpoint=" in connection_string:
             ret = azure_file_upload(file_path_local, connection_string, self.config_data[g_FTM][g_Share_Name], self.file_path_remote)
             return ret
-        elif "gcs-bucket-upload" in connection_string:
+        elif "upload-file-to-bucket" in connection_string:
             return gcp_file_upload(
                 endpoint=connection_string,
                 api_key=api_key,

--- a/lib/python/satos_payload_sdk/antaris_file_download.py
+++ b/lib/python/satos_payload_sdk/antaris_file_download.py
@@ -9,6 +9,7 @@ logger.setLevel(logging.WARNING)
 gHttpOk = 200
 g_FTM = "FTM"
 g_File_String = "File_Conn_Str"
+g_API_Key = "File_Share_API_Key"
 g_Truetwin_Dir = "Truetwin_Dir"
 g_Share_Name = "Share_Name"
 g_Outbound_Path_Prefix = "/opt/antaris/outbound/"
@@ -24,6 +25,7 @@ class File_Stage():
     def start_upload(self):
         file_path_local = g_Outbound_Path_Prefix + self.download_file_params.file_path
         connection_string = self.config_data[g_FTM][g_File_String]
+        api_key = self.config_data[g_FTM][g_API_Key],
         
         if "FileEndpoint=" in connection_string:
             ret = azure_file_upload(file_path_local, connection_string, self.config_data[g_FTM][g_Share_Name], self.file_path_remote)
@@ -31,6 +33,7 @@ class File_Stage():
         elif "gcs-bucket-upload" in connection_string:
             return gcp_file_upload(
                 endpoint=connection_string,
+                api_key=api_key,
                 file_path=file_path_local,
                 gcs_bucket=self.config_data[g_FTM][g_Share_Name],
                 truetwin_dir=self.config_data[g_FTM][g_Truetwin_Dir],
@@ -53,18 +56,21 @@ def azure_file_upload(file_name, conn_str, share_name, file_path):
         logger.error(f"Error message: {str(e)}")
         return False
 
-def gcp_file_upload(endpoint, file_path, gcs_bucket, truetwin_dir, filename):
+def gcp_file_upload(endpoint, api_key ,file_path, gcs_bucket, truetwin_dir, filename):
     try:
         with open(file_path, 'rb') as f:
             files = {
                 'file': (filename, f),
+            }
+            headers = {
+                'X-API-Key': api_key
             }
             data = {
                 'gcs_bucket': gcs_bucket,
                 'truetwin_dir': truetwin_dir,
                 'filename': filename,
             }
-            response = requests.post(endpoint, files=files, data=data)
+            response = requests.post(endpoint, files=files, data=data, headers=headers)
 
         if response.status_code == gHttpOk:
             return True

--- a/lib/python/satos_payload_sdk/gen/antaris_sdk_version.py
+++ b/lib/python/satos_payload_sdk/gen/antaris_sdk_version.py
@@ -11,7 +11,7 @@ This is an auto-generated file. Any manual changes to this file will neither be 
 ANTARIS_SDK_BUILD_USER="uid=0(root) gid=0(root) groups=0(root)"
 
 
-ANTARIS_SDK_BUILD_TIME="Mon Sep 15 06:59:01 UTC 2025"
+ANTARIS_SDK_BUILD_TIME="Fri Sep 19 08:24:00 UTC 2025"
 
 
 ANTARIS_PA_PC_SDK_VERSION='1.1.1'

--- a/lib/python/satos_payload_sdk/gen/antaris_sdk_version.py
+++ b/lib/python/satos_payload_sdk/gen/antaris_sdk_version.py
@@ -11,7 +11,7 @@ This is an auto-generated file. Any manual changes to this file will neither be 
 ANTARIS_SDK_BUILD_USER="uid=0(root) gid=0(root) groups=0(root)"
 
 
-ANTARIS_SDK_BUILD_TIME="Mon Sep 15 06:59:01 UTC 2025"
+ANTARIS_SDK_BUILD_TIME="Wed Sep 17 08:54:05 UTC 2025"
 
 
 ANTARIS_PA_PC_SDK_VERSION='1.1.1'

--- a/lib/python/satos_payload_sdk/gen/antaris_sdk_version.py
+++ b/lib/python/satos_payload_sdk/gen/antaris_sdk_version.py
@@ -11,7 +11,7 @@ This is an auto-generated file. Any manual changes to this file will neither be 
 ANTARIS_SDK_BUILD_USER="uid=0(root) gid=0(root) groups=0(root)"
 
 
-ANTARIS_SDK_BUILD_TIME="Wed Sep 17 08:54:05 UTC 2025"
+ANTARIS_SDK_BUILD_TIME="Mon Sep 15 06:59:01 UTC 2025"
 
 
 ANTARIS_PA_PC_SDK_VERSION='1.1.1'


### PR DESCRIPTION
Currently, we use cloud run service that processes the file upload task. But we are moving to containerizing the cloud service and add auth layer with api-key. The containerized service will check the api-key first and then upload the file.