### PR TITLE
Added post registration callback

### DIFF
--- a/examples/app-python/example_app.py
+++ b/examples/app-python/example_app.py
@@ -55,6 +55,17 @@ logger = logging.getLogger()
 
 class Controller:
 
+    # After payload app successfully registered to PC, then this callback is called
+    def post_registration_func(self, client):
+        logger.info("Callback to perform post registration activities")
+        command = 1  # UINT16 dummy command
+        payload_data = bytes([0x12, 0x34, 0x56])  # Can be up to 1020 bytes
+
+        resp = client.pa_satos_message(command, payload_data)
+        logger.info(f"Command id = {resp.command_id} , status = {resp.req_status}")
+
+        return True
+
     def is_healthy(self):
         logger.info("Health check succeeded")
         return True
@@ -544,6 +555,7 @@ def new():
     ctl = Controller()
 
     app = app_framework.PayloadApplication()
+    app.set_post_registration_cb(ctl.post_registration_func)   # Registering post registration callback 
     app.set_health_check(ctl.is_healthy)
     app.set_gnss_eph_data_cb(ctl.gnss_eph_data_handler)
     app.set_get_eps_voltage_cb(ctl.get_eps_voltage_handler)

--- a/lib/python/satos_payload_sdk/app_framework.py
+++ b/lib/python/satos_payload_sdk/app_framework.py
@@ -135,7 +135,7 @@ class SequenceHandler(Stoppable, threading.Thread):
 
 
 class ChannelClient:
-    def __init__(self, start_sequence_cb, health_check_cb, shutdown_cb, req_payload_metrics_cb, gnss_eph_data_cb, get_eps_voltage_cb, ses_thermal_ntf_cb, remote_ac_power_on_ntf, payload_power_control_request_status, process_notify_fcm_operation_cb, process_post_reg_db):
+    def __init__(self, start_sequence_cb, health_check_cb, shutdown_cb, req_payload_metrics_cb, gnss_eph_data_cb, get_eps_voltage_cb, ses_thermal_ntf_cb, remote_ac_power_on_ntf, payload_power_control_request_status, process_notify_fcm_operation_cb, process_post_reg_cb):
         self._channel = None
         self._cond = threading.Condition()
         self._next_cid = 0
@@ -167,7 +167,7 @@ class ChannelClient:
             'PaSatOsMsg': self._handle_response,
             'RemoteAcPowerStatusNtf': remote_ac_power_on_ntf,
             'FcmOperationNotify': process_notify_fcm_operation_cb,
-            'PostRegistrationCb' : process_post_reg_db
+            'PostRegistrationCb' : process_post_reg_cb
         }
 
     def _get_next_cid(self):

--- a/lib/python/satos_payload_sdk/app_framework.py
+++ b/lib/python/satos_payload_sdk/app_framework.py
@@ -135,7 +135,7 @@ class SequenceHandler(Stoppable, threading.Thread):
 
 
 class ChannelClient:
-    def __init__(self, start_sequence_cb, health_check_cb, shutdown_cb, req_payload_metrics_cb, gnss_eph_data_cb, get_eps_voltage_cb, ses_thermal_ntf_cb, remote_ac_power_on_ntf, payload_power_control_request_status, process_notify_fcm_operation_cb):
+    def __init__(self, start_sequence_cb, health_check_cb, shutdown_cb, req_payload_metrics_cb, gnss_eph_data_cb, get_eps_voltage_cb, ses_thermal_ntf_cb, remote_ac_power_on_ntf, payload_power_control_request_status, process_notify_fcm_operation_cb, process_post_reg_db):
         self._channel = None
         self._cond = threading.Condition()
         self._next_cid = 0
@@ -166,7 +166,8 @@ class ChannelClient:
             'SesThrmlStsNtf': ses_thermal_ntf_cb,
             'PaSatOsMsg': self._handle_response,
             'RemoteAcPowerStatusNtf': remote_ac_power_on_ntf,
-            'FcmOperationNotify': process_notify_fcm_operation_cb
+            'FcmOperationNotify': process_notify_fcm_operation_cb,
+            'PostRegistrationCb' : process_post_reg_db
         }
 
     def _get_next_cid(self):
@@ -492,6 +493,9 @@ class PayloadApplication(Stoppable):
         # index of registered sequence handler funcs
         self.sequence_handler_func_idx = dict()
 
+        # post registration callback function
+        self._post_registration_cb = lambda: True
+
         # default health check; can be overridden
         self.health_check_handler_func = lambda: True
         
@@ -519,6 +523,10 @@ class PayloadApplication(Stoppable):
     # to represent health check success or failure, respectively
     def set_health_check(self, health_check_handler_func):
         self.health_check_handler_func = health_check_handler_func
+
+    # Provided function should expect no arguments and return True or False
+    def set_post_registration_cb(self, set_post_registration_func):
+        self._post_registration_cb = set_post_registration_func
 
     # Provided function should expect no arguments and return True or False
     # to represent gnss eph data handling, respectively
@@ -567,9 +575,11 @@ class PayloadApplication(Stoppable):
         logger.info("payload app starting")
 
         if not self.channel_client:
-            self.channel_client = ChannelClient(self.start_sequence, self._handle_health_check, self._handle_shutdown, self._req_payload_metrics, self._set_gnss_eph_data_cb, self._set_get_eps_voltage_cb, self._set_ses_thermal_status_ntf, self._remote_ac_power_on_ntf, self._payload_power_control_request_status, self._set_process_notify_fcm_operation_cb)
+            self.channel_client = ChannelClient(self.start_sequence, self._handle_health_check, self._handle_shutdown, self._req_payload_metrics, self._set_gnss_eph_data_cb, self._set_get_eps_voltage_cb, self._set_ses_thermal_status_ntf, self._remote_ac_power_on_ntf, self._payload_power_control_request_status, self._set_process_notify_fcm_operation_cb, self._set_post_registration_cb)
         
         self.channel_client._connect()
+
+        self._post_registration_cb(self.channel_client)
 
         logger.info("payload app running")
 
@@ -665,6 +675,13 @@ class PayloadApplication(Stoppable):
             logger.error("sequence_done request failed: resp=%d" % resp)
 
         return api_types.AntarisReturnCode.An_SUCCESS
+
+    def _set_post_registration_cb(self, params):
+        logger.info("Handling post registration callback")
+        try:
+            hv = self.set_post_registration_cb(params)
+        except:
+            logger.exception("Post registration callback failed")
 
     def _set_gnss_eph_data_cb(self, params):
         logger.info("Handling GNSS EPH data")


### PR DESCRIPTION
Use case:
Payload may want to send "application active" message to SatOS once channel is established between Payload and Payload server. "Post registration callback" can be used for this.