### PR TITLE
convert docker image name to lower case

### DIFF
--- a/utilities/create_payload_tarball.sh
+++ b/utilities/create_payload_tarball.sh
@@ -257,6 +257,9 @@ export VM_IP_ADDRESS=$(jq -r '.Network.VM_IP_Address' "$config_json_path")
 export APP_CONTROLLER_IP=$(jq -r '.Network.Application_Controller_IP_Address' "$config_json_path")
 export COOKIE=$(jq -r '.cookie' "$config_json_path")
 
+# convert docker image name to small letters.
+VM_NAME=$(echo "$VM_NAME" | tr '[:upper:]' '[:lower:]')
+
 # Delete last 3 characters of COOKIE
 COOKIE="${COOKIE::-3}"
 


### PR DESCRIPTION
The docker image name extracted from config file starts with a capital letter. but docker image can't start with capital letter. hence converting it to lower case before building image.